### PR TITLE
[fix] generation of range redactors

### DIFF
--- a/lib/redact_ex/configuration.ex
+++ b/lib/redact_ex/configuration.ex
@@ -139,7 +139,7 @@ defmodule RedactEx.Configuration do
         lengths
 
       # range case
-      {:.., [line: _], [min, max]} ->
+      {:.., _context, [min, max]} ->
         Enum.map(min..max, & &1)
 
       other ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule RedactEx.MixProject do
   def project do
     [
       app: :redact_ex,
-      version: "0.1.5",
+      version: "0.1.6",
       source_url: "https://github.com/primait/redact_ex",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/overload_redactor_test.exs
+++ b/test/overload_redactor_test.exs
@@ -3,11 +3,18 @@ defmodule RedactEx.OverloadRedactTest do
 
   alias Support.RedactEx.OverloadTestRedactor
 
-  test "1-length, 5-length and 8-length redactors are exported" do
+  test "1-length, 2-length and 3..5-length redactors are exported" do
     assert OverloadTestRedactor.overload("1") == "*"
     assert OverloadTestRedactor.overload("12") == "**"
     assert OverloadTestRedactor.overload("123") == "***"
     assert OverloadTestRedactor.overload("1234") == "1***"
+    assert OverloadTestRedactor.overload("1235") == "1***"
+  end
+
+  test "7..9-length use custom redactor" do
+    assert OverloadTestRedactor.overload("1234567") == "(custom precise redact len 7) 1234567"
+    assert OverloadTestRedactor.overload("12345678") == "(custom precise redact len 8) 12345678"
+    assert OverloadTestRedactor.overload("123456789") == "(custom precise redact len 9) 123456789"
   end
 
   test "fallback reload work as expected" do

--- a/test/support/algorithms/custom_precise_algorithm.ex
+++ b/test/support/algorithms/custom_precise_algorithm.ex
@@ -1,0 +1,17 @@
+defmodule Support.RedactEx.Algorithms.CustomPreciseAlgorithm do
+  @moduledoc false
+
+  @behaviour RedactEx.Algorithms.Algorithm
+
+  @impl RedactEx.Algorithms.Algorithm
+  def generate_ast(%{name: name, length: len}) do
+    quote do
+      def unquote(name)(<<head::binary-size(unquote(len))>> = value) do
+        "(custom precise redact len #{unquote(len)}) #{value}"
+      end
+    end
+  end
+
+  @impl RedactEx.Algorithms.Algorithm
+  def parse_extra_configuration!(_), do: %{}
+end

--- a/test/support/overload_test_redactor.ex
+++ b/test/support/overload_test_redactor.ex
@@ -1,10 +1,13 @@
 defmodule Support.RedactEx.OverloadTestRedactor do
   @moduledoc false
 
+  alias Support.RedactEx.Algorithms.CustomPreciseAlgorithm
+
   use RedactEx.Redactor,
     redactors: [
       {:overload, length: 1},
       {:overload, length: 2},
-      {:overload, lengths: 3..4}
+      {:overload, lengths: 3..5},
+      {:overload, lengths: 7..9, algorithm: CustomPreciseAlgorithm}
     ]
 end


### PR DESCRIPTION
A wrong match prevented ranges to be correctly generated
