### PR TITLE
Remove unnecessary container option from alls green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,6 @@ jobs:
     needs:
       - test
     runs-on: ubuntu-latest
-    container:
-      image: public.ecr.aws/prima/python:3.9.10-3
     steps:
         - name: Decide whether the needed jobs succeeded or failed
           uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
Using a container is only necessary if you use the prima hosted runners, since they don't have python installed. On ubuntu-latest runners it's cleaner and faster to just use the action normally

Thanks to @EddieWhi for pointing this out on slack